### PR TITLE
[WIP] Better time-period storage/iteration, and use of internal states

### DIFF
--- a/examples/routing/Project.toml
+++ b/examples/routing/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ClimaRivers = "9363829b-25e6-4e43-a03e-985c67d112e3"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/examples/routing/gamma_IRF.jl
+++ b/examples/routing/gamma_IRF.jl
@@ -39,7 +39,11 @@ end
 data_start_date = Date("1996-01-01", "yyyy-mm-dd")
 data_end_date = Date("2014-12-31", "yyyy-mm-dd") # of entire simulation
 data_step = Day(1)
-data_date_window = DateWindow(start_date=data_start_date, end_date=data_end_date, date_step=data_step)
+data_date_window = DateWindow(
+    start_date = data_start_date,
+    end_date = data_end_date,
+    date_step = data_step,
+)
 
 # build environment
 env = Environment(
@@ -53,17 +57,17 @@ env = Environment(
 )
 
 
-## evolutionary model, evolving a state over time
-model_types = ["instant"]
-model_type = model_types[1]
+# River state loaded into csv files currently, placehodler variable
+history_length = 50 * Day(1)
+@info "using history length $(history_length)"
+initial_window = DateWindow(
+    start_date = data_start_date,
+    end_date = data_start_date + history_length,
+    date_step = data_step,
+)
 
-# streamflow = zeros(dates,basins)
-hillslope_data = zeros(10, 10)  # Replace with actual data once implemented
-channel_data = zeros(10, 10)   # Replace with actual data once implemented
+## full-timeseries model, predicts all states at once
+@info "computing streamflow over network $(history_length)"
 
-river_state = HillslopeChannelRiverState(hillslope_data, channel_data)
-
-if model_type == "instant"
-    ## full-timeseries model, predicts all states at once
-    compute_streamflow!(river_state, river_model, env, data_start_date, data_end_date)
-end
+streamflows, river_states =
+    compute_streamflow(initial_window, river_model, env, data_end_date)

--- a/examples/routing/gamma_IRF.jl
+++ b/examples/routing/gamma_IRF.jl
@@ -69,13 +69,19 @@ initial_window = DateWindow(
 ## full-timeseries model, predicts all states at once
 @info "computing streamflow over network $(history_length)"
 ttt = @elapsed begin
-streamflows, river_states =
-    compute_streamflow(initial_window, river_model, env, data_end_date)
+    streamflows, river_states =
+        compute_streamflow(initial_window, river_model, env, data_end_date)
 end
 @info "Complete. Time taken: $ttt"
 
 #  save data
-JLD2.save(joinpath(output_dir,"streamflow_history$(history_length).jld2"),"streamflows", streamflows, "river_states",river_states)
+JLD2.save(
+    joinpath(output_dir, "streamflow_history$(history_length).jld2"),
+    "streamflows",
+    streamflows,
+    "river_states",
+    river_states,
+)
 ## load data with
 # Using ClimaRivers, JLD2
 # load("filepath")

--- a/examples/routing/gamma_IRF.jl
+++ b/examples/routing/gamma_IRF.jl
@@ -35,12 +35,19 @@ if !isdir(output_dir)
     mkpath(output_dir)
 end
 
+# data date information
+data_start_date = Date("1996-01-01", "yyyy-mm-dd")
+data_end_date = Date("2014-12-31", "yyyy-mm-dd") # of entire simulation
+data_step = Day(1)
+data_date_window = DateWindow(start_date=data_start_date, end_date=data_end_date, date_step=data_step)
+
 # build environment
 env = Environment(
     basin_ids_file = basin_ids_file,
     attributes_file = attributes_file,
     graph_file = graph_file,
     forcing_timeseries_dir = forcing_timeseries_dir,
+    date_window = data_date_window,
     output_dir = output_dir,
     forcing_timeseries_file_prefix = "basin_",
 )
@@ -50,17 +57,13 @@ env = Environment(
 model_types = ["instant"]
 model_type = model_types[1]
 
-start_date = Date("1996-01-01", "yyyy-mm-dd")
-end_date = Date("2014-12-31", "yyyy-mm-dd")
-dates = collect(start_date:Day(1):end_date)
-
 # streamflow = zeros(dates,basins)
 hillslope_data = zeros(10, 10)  # Replace with actual data once implemented
 channel_data = zeros(10, 10)   # Replace with actual data once implemented
 
-river_state = RiverState(hillslope_data, channel_data)
+river_state = HillslopeChannelRiverState(hillslope_data, channel_data)
 
 if model_type == "instant"
     ## full-timeseries model, predicts all states at once
-    compute_streamflow!(river_state, river_model, env, start_date, end_date)
+    compute_streamflow!(river_state, river_model, env, data_start_date, data_end_date)
 end

--- a/examples/routing/gamma_IRF.jl
+++ b/examples/routing/gamma_IRF.jl
@@ -1,5 +1,5 @@
 using ClimaRivers
-using JSON, Dates
+using JSON, Dates, JLD2
 
 # build hillslope model
 hillslope = MizurouteHillslopeV1{Float64}()
@@ -68,6 +68,14 @@ initial_window = DateWindow(
 
 ## full-timeseries model, predicts all states at once
 @info "computing streamflow over network $(history_length)"
-
+ttt = @elapsed begin
 streamflows, river_states =
     compute_streamflow(initial_window, river_model, env, data_end_date)
+end
+@info "Complete. Time taken: $ttt"
+
+#  save data
+JLD2.save(joinpath(output_dir,"streamflow_history$(history_length).jld2"),"streamflows", streamflows, "river_states",river_states)
+## load data with
+# Using ClimaRivers, JLD2
+# load("filepath")

--- a/examples/routing/gamma_IRF.jl
+++ b/examples/routing/gamma_IRF.jl
@@ -58,7 +58,7 @@ env = Environment(
 
 
 # River state loaded into csv files currently, placehodler variable
-history_length = 50 * Day(1)
+history_length = 120 * Day(1)
 @info "using history length $(history_length)"
 initial_window = DateWindow(
     start_date = data_start_date,

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -35,30 +35,37 @@ if !isdir(output_dir)
     mkpath(output_dir)
 end
 
+# data information
+data_start_date = Date("1996-01-01", "yyyy-mm-dd")
+data_end_date = Date("2014-12-31", "yyyy-mm-dd") # of entire simulation
+data_step = Day(1)
+data_date_window = DateWindow(start_date=data_start_date, end_date=data_end_date, date_step=data_step)
+
 # build environment
 env = Environment(
     basin_ids_file = basin_ids_file,
     attributes_file = attributes_file,
     graph_file = graph_file,
     forcing_timeseries_dir = forcing_timeseries_dir,
+    date_window = data_date_window,
     output_dir = output_dir,
     forcing_timeseries_file_prefix = "basin_",
 )
+
 
 ## evolutionary model, evolving a state over time
 model_types = ["instant"]
 model_type = model_types[1]
 
-start_date = Date("1996-01-01", "yyyy-mm-dd")
-end_date = Date("2014-12-31", "yyyy-mm-dd")
+
 
 # River state loaded into csv files currently, placehodler variable
 hillslope_data = zeros(10, 10)
 channel_data = zeros(10, 10)
 
-river_state = RiverState(hillslope_data, channel_data)
+river_state = HillslopeChannelRiverState(hillslope_data, channel_data)
 
 if model_type == "instant"
     ## full-timeseries model, predicts all states at once
-    compute_streamflow!(river_state, river_model, env, start_date, end_date)
+    compute_streamflow!(river_state, river_model, env, data_start_date, data_end_date)
 end

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -72,4 +72,9 @@ streamflows, river_states =
     compute_streamflow(initial_window, river_model, env, data_end_date)
 end
 @info "Complete. Time taken: $ttt"
-JLD2.save(joinpath(output_dir,"streamflow_history$(history_length).jld2"),"streamflow", streamflows, "river_states",river_states)
+
+#  save data
+JLD2.save(joinpath(output_dir,"streamflow_history$(history_length).jld2"),"streamflows", streamflows, "river_states",river_states)
+## load data with
+# Using ClimaRivers, JLD2
+# load("filepath")

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -68,13 +68,19 @@ initial_window = DateWindow(
 ## full-timeseries model, predicts all states at once
 @info "computing streamflow over network $(history_length)"
 ttt = @elapsed begin
-streamflows, river_states =
-    compute_streamflow(initial_window, river_model, env, data_end_date)
+    streamflows, river_states =
+        compute_streamflow(initial_window, river_model, env, data_end_date)
 end
 @info "Complete. Time taken: $ttt"
 
 #  save data
-JLD2.save(joinpath(output_dir,"streamflow_history$(history_length).jld2"),"streamflows", streamflows, "river_states",river_states)
+JLD2.save(
+    joinpath(output_dir, "streamflow_history$(history_length).jld2"),
+    "streamflows",
+    streamflows,
+    "river_states",
+    river_states,
+)
 ## load data with
 # Using ClimaRivers, JLD2
 # load("filepath")

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -57,7 +57,7 @@ env = Environment(
 )
 
 # River state loaded into csv files currently, placehodler variable
-history_length = 50 * Day(1)
+history_length = 120 * Day(1)
 @info "using history length $(history_length)"
 initial_window = DateWindow(
     start_date = data_start_date,

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -58,6 +58,7 @@ env = Environment(
 
 # River state loaded into csv files currently, placehodler variable
 history_length = 50 * Day(1)
+@info "using history length $(history_length)"
 initial_window = DateWindow(
     start_date = data_start_date,
     end_date = data_start_date + history_length,
@@ -65,5 +66,6 @@ initial_window = DateWindow(
 )
 
 ## full-timeseries model, predicts all states at once
+@info "computing streamflow over network $(history_length)"
 streamflows, river_states =
     compute_streamflow(initial_window, river_model, env, data_end_date)

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -39,7 +39,11 @@ end
 data_start_date = Date("1996-01-01", "yyyy-mm-dd")
 data_end_date = Date("2014-12-31", "yyyy-mm-dd") # of entire simulation
 data_step = Day(1)
-data_date_window = DateWindow(start_date=data_start_date, end_date=data_end_date, date_step=data_step)
+data_date_window = DateWindow(
+    start_date = data_start_date,
+    end_date = data_end_date,
+    date_step = data_step,
+)
 
 # build environment
 env = Environment(
@@ -52,20 +56,14 @@ env = Environment(
     forcing_timeseries_file_prefix = "basin_",
 )
 
-
-## evolutionary model, evolving a state over time
-model_types = ["instant"]
-model_type = model_types[1]
-
-
-
 # River state loaded into csv files currently, placehodler variable
-hillslope_data = zeros(10, 10)
-channel_data = zeros(10, 10)
+history_length = 50 * Day(1)
+initial_window = DateWindow(
+    start_date = data_start_date,
+    end_date = data_start_date + history_length,
+    date_step = data_step,
+)
 
-river_state = HillslopeChannelRiverState(hillslope_data, channel_data)
-
-if model_type == "instant"
-    ## full-timeseries model, predicts all states at once
-    compute_streamflow!(river_state, river_model, env, data_start_date, data_end_date)
-end
+## full-timeseries model, predicts all states at once
+streamflows, river_states =
+    compute_streamflow(initial_window, river_model, env, data_end_date)

--- a/examples/routing/mini_gamma_IRF.jl
+++ b/examples/routing/mini_gamma_IRF.jl
@@ -1,5 +1,5 @@
 using ClimaRivers
-using JSON, Dates
+using JSON, Dates, JLD2
 
 # build hillslope model
 hillslope = MizurouteHillslopeV1{Float64}()
@@ -30,7 +30,7 @@ forcing_timeseries_dir =
     joinpath(data_file_path, "timeseries", "timeseries_lv05")
 output_dir =
     joinpath(data_file_path, "simulations", "simulations_lv05", "gamma_IRF")
-@info "creating output path"
+@info "output path: $output_dir"
 if !isdir(output_dir)
     mkpath(output_dir)
 end
@@ -67,5 +67,9 @@ initial_window = DateWindow(
 
 ## full-timeseries model, predicts all states at once
 @info "computing streamflow over network $(history_length)"
+ttt = @elapsed begin
 streamflows, river_states =
     compute_streamflow(initial_window, river_model, env, data_end_date)
+end
+@info "Complete. Time taken: $ttt"
+JLD2.save(joinpath(output_dir,"streamflow_history$(history_length).jld2"),"streamflow", streamflows, "river_states",river_states)

--- a/src/ClimaRivers.jl
+++ b/src/ClimaRivers.jl
@@ -6,8 +6,8 @@ using LinearAlgebra,
 
 # includes
 include("Environments.jl")
-include("States.jl")
 include("RiverModels.jl")
+include("States.jl")
 include("Routing.jl")
 include("MizurouteV1.jl")
 end # module ClimaRivers

--- a/src/Environments.jl
+++ b/src/Environments.jl
@@ -173,14 +173,14 @@ function Environment(
     forcing_timeseries_files::AV,
     date_window::DateWindow,
     output_dir::AS4;
-    ) where {
-        AS1 <: AbstractString,
-        AS2 <: AbstractString,
-        AS3 <: AbstractString,
-        AS4 <: AbstractString,
-        AV <: AbstractVector,
-    }
-    
+) where {
+    AS1 <: AbstractString,
+    AS2 <: AbstractString,
+    AS3 <: AbstractString,
+    AS4 <: AbstractString,
+    AV <: AbstractVector,
+}
+
     static_env = StaticEnvironment(basin_ids_file, attributes_file, graph_file)
     basin_ids = static_env.basin_ids
     dynamic_env = DynamicEnvironment(
@@ -191,7 +191,7 @@ function Environment(
     )
 
     return Environment(static_env, dynamic_env)
-    
+
 end
 
 """
@@ -209,15 +209,15 @@ function Environment(
     date_window::DateWindow,
     output_dir::AS5;
     forcing_timeseries_file_prefix = "basin_",
-    ) where {
-        AS1 <: AbstractString,
-        AS2 <: AbstractString,
-        AS3 <: AbstractString,
-        AS4 <: AbstractString,
-        AS5 <: AbstractString,
-    }
+) where {
+    AS1 <: AbstractString,
+    AS2 <: AbstractString,
+    AS3 <: AbstractString,
+    AS4 <: AbstractString,
+    AS5 <: AbstractString,
+}
     static_env = StaticEnvironment(basin_ids_file, attributes_file, graph_file)
-    
+
     basin_ids = static_env.basin_ids
     forcing_timeseries_files = [
         joinpath(
@@ -233,7 +233,7 @@ function Environment(
     )
 
     return Environment(static_env, dynamic_env)
-    
+
 end
 
 """
@@ -242,15 +242,15 @@ $(TYPEDSIGNATURES)
 Constructor based on keywords, where users must provide either `forcing_timeseries_dir` or `forcing_timeseries_files`.
 """
 function Environment(;
-                     basin_ids_file::Union{String, Nothing} = nothing,
-                     attributes_file::Union{String, Nothing} = nothing,
-                     graph_file::Union{String, Nothing} = nothing,
-                     forcing_timeseries_dir::Union{String, Nothing} = nothing,
-                     output_dir::Union{String, Nothing} = nothing,
-                     date_window::Union{DateWindow, Nothing} = nothing,
-                     forcing_timeseries_file_prefix::String = "basin_",
-                     forcing_timeseries_files::Union{<:Vector{String}, Nothing} = nothing,
-                     ) # union with nothing is not allowed a "where" statement, see detect_unbound_args in Aqua.jl
+    basin_ids_file::Union{String, Nothing} = nothing,
+    attributes_file::Union{String, Nothing} = nothing,
+    graph_file::Union{String, Nothing} = nothing,
+    forcing_timeseries_dir::Union{String, Nothing} = nothing,
+    output_dir::Union{String, Nothing} = nothing,
+    date_window::Union{DateWindow, Nothing} = nothing,
+    forcing_timeseries_file_prefix::String = "basin_",
+    forcing_timeseries_files::Union{<:Vector{String}, Nothing} = nothing,
+) # union with nothing is not allowed a "where" statement, see detect_unbound_args in Aqua.jl
     arg_list_one = [basin_ids_file, attributes_file, graph_file, output_dir]
     any_nothing = any([isnothing(x) for x in arg_list_one])
     if any_nothing

--- a/src/Environments.jl
+++ b/src/Environments.jl
@@ -55,7 +55,7 @@ function StaticEnvironment(
     # create attributes
     attributes = CSV.read(attributes_file, DataFrame)
 
-    # create graph, and make it inter-valued
+    # create graph
     graph_dict = JSON.parsefile(graph_file)
 
 

--- a/src/Environments.jl
+++ b/src/Environments.jl
@@ -56,7 +56,41 @@ function StaticEnvironment(
     return StaticEnvironment(basin_ids, attributes, graph_dict)
 end
 
+# Some time information of the data
+export DateWindow
+
+"""
+$(TYPEDEF)
+
+Stores a dated time period with an iterator.
+
+$(TYPEDFIELDS)
+"""
+struct DateWindow
+    "beginning of date window [Date]"
+    start_date::Date
+    "end of date window [Date]"
+    end_date::Date
+    "size of iteration in date window [DatePeriod]"
+    date_step::DatePeriod
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+build a DateWindow with keyword arguments.
+"""
+function DateWindow(;
+    start_date::Union{Date,Nothing} = nothing,
+    end_date::Union{Date,Nothing} = nothing,
+    date_step::Union{DatePeriod,Nothing} = nothing,
+    )
+    return DateWindow(start_date, end_date, date_step)
+    
+end
+
 # Dynamic Data Objects
+
 """
 $(TYPEDEF)
 
@@ -67,6 +101,8 @@ $(TYPEDFIELDS)
 struct DynamicEnvironment
     "Dictionary of pairs `(basin_id => forcing timeseries [DataFrame] at basin_id)`"
     forcing_timeseries::Dict
+    "Window over which the forcing timeseries is defined [DateWindow]"
+    date_window::DateWindow
     "Directory to store simulation results"
     output_dir::String
 end
@@ -79,6 +115,7 @@ Constructor of `DynamicEnvironment` from a vector of `basin_id`s, and a vector o
 function DynamicEnvironment(
     basin_ids::AV1,
     forcing_timeseries_files::AV2,
+    date_window::DateWindow,
     output_dir::String,
 ) where {AV1 <: AbstractVector, AV2 <: AbstractVector}
 
@@ -89,7 +126,7 @@ function DynamicEnvironment(
     end
     forcing_timeseries = Dict(eachrow([basin_ids forcing_timeseries_array])) # creates id => timeseries dictionary
 
-    return DynamicEnvironment(forcing_timeseries, output_dir)
+    return DynamicEnvironment(forcing_timeseries, date_window, output_dir)
 end
 
 
@@ -111,28 +148,29 @@ end
 $(TYPEDSIGNATURES)
 
 Constructor of `Enviroment` using a list of forcing timeseries files. See constructors for StaticEnvironment and DynamicEnvironment for more details on other inputs.
-"""
+            """
 function Environment(
     basin_ids_file::AS1,
     attributes_file::AS2,
     graph_file::AS3,
     forcing_timeseries_files::AV,
-    output_dir::AS4,
-) where {
-    AS1 <: AbstractString,
-    AS2 <: AbstractString,
-    AS3 <: AbstractString,
-    AS4 <: AbstractString,
-    AV <: AbstractVector,
-}
-
+    date_window::DateWindow,
+    output_dir::AS4;
+    ) where {
+        AS1 <: AbstractString,
+        AS2 <: AbstractString,
+        AS3 <: AbstractString,
+        AS4 <: AbstractString,
+        AV <: AbstractVector,
+    }
+    
     static_env = StaticEnvironment(basin_ids_file, attributes_file, graph_file)
     basin_ids = static_env.basin_ids
     dynamic_env =
-        DynamicEnvironment(basin_ids, forcing_timeseries_files, output_dir)
-
+        DynamicEnvironment(basin_ids, forcing_timeseries_files, date_window, output_dir)
+    
     return Environment(static_env, dynamic_env)
-
+    
 end
 
 """
@@ -147,29 +185,30 @@ function Environment(
     attributes_file::AS2,
     graph_file::AS3,
     forcing_timeseries_dir::AS4,
+    date_window::DateWindow,
     output_dir::AS5;
     forcing_timeseries_file_prefix = "basin_",
-) where {
-    AS1 <: AbstractString,
-    AS2 <: AbstractString,
-    AS3 <: AbstractString,
-    AS4 <: AbstractString,
-    AS5 <: AbstractString,
-}
+    ) where {
+        AS1 <: AbstractString,
+        AS2 <: AbstractString,
+        AS3 <: AbstractString,
+        AS4 <: AbstractString,
+        AS5 <: AbstractString,
+    }
     static_env = StaticEnvironment(basin_ids_file, attributes_file, graph_file)
-
+    
     basin_ids = static_env.basin_ids
     forcing_timeseries_files = [
         joinpath(
             forcing_timeseries_dir,
             forcing_timeseries_file_prefix * "$(id).csv",
         ) for id in basin_ids
-    ]
+            ]
     dynamic_env =
-        DynamicEnvironment(basin_ids, forcing_timeseries_files, output_dir)
+        DynamicEnvironment(basin_ids, forcing_timeseries_files, date_window, output_dir)
 
     return Environment(static_env, dynamic_env)
-
+    
 end
 
 """
@@ -178,14 +217,15 @@ $(TYPEDSIGNATURES)
 Constructor based on keywords, where users must provide either `forcing_timeseries_dir` or `forcing_timeseries_files`.
 """
 function Environment(;
-    basin_ids_file::Union{String, Nothing} = nothing,
-    attributes_file::Union{String, Nothing} = nothing,
-    graph_file::Union{String, Nothing} = nothing,
-    forcing_timeseries_dir::Union{String, Nothing} = nothing,
-    output_dir::Union{String, Nothing} = nothing,
-    forcing_timeseries_file_prefix::String = "basin_",
-    forcing_timeseries_files::Union{<:Vector{String}, Nothing} = nothing,
-) # union with nothing is not allowed a "where" statement, see detect_unbound_args in Aqua.jl
+                     basin_ids_file::Union{String, Nothing} = nothing,
+                     attributes_file::Union{String, Nothing} = nothing,
+                     graph_file::Union{String, Nothing} = nothing,
+                     forcing_timeseries_dir::Union{String, Nothing} = nothing,
+                     output_dir::Union{String, Nothing} = nothing,
+                     date_window::Union{DateWindow, Nothing} = nothing,
+                     forcing_timeseries_file_prefix::String = "basin_",
+                     forcing_timeseries_files::Union{<:Vector{String}, Nothing} = nothing,
+                     ) # union with nothing is not allowed a "where" statement, see detect_unbound_args in Aqua.jl
     arg_list_one = [basin_ids_file, attributes_file, graph_file, output_dir]
     any_nothing = any([isnothing(x) for x in arg_list_one])
     if any_nothing
@@ -221,6 +261,7 @@ Environment must be built with values for all these keywords. But received:\n
             attributes_file,
             graph_file,
             forcing_timeseries_files,
+            date_window,
             output_dir,
         )
     elseif isnothing(forcing_timeseries_files)
@@ -229,6 +270,7 @@ Environment must be built with values for all these keywords. But received:\n
             attributes_file,
             graph_file,
             forcing_timeseries_dir,
+            date_window,
             output_dir,
             forcing_timeseries_file_prefix = forcing_timeseries_file_prefix,
         )

--- a/src/Environments.jl
+++ b/src/Environments.jl
@@ -1,6 +1,11 @@
 # Contains the structs that define the static and dynamic environment that configures/forces the river model.
 using JSON, CSV, DataFrames
+
+import Base.iterate
+
 export StaticEnvironment, DynamicEnvironment, Environment
+export DateWindow
+export get_all_dates, iterate
 
 ## Auxiliary functions
 # function for reading basins from txt file into Vector{Int}
@@ -50,14 +55,14 @@ function StaticEnvironment(
     # create attributes
     attributes = CSV.read(attributes_file, DataFrame)
 
-    # create graph
+    # create graph, and make it inter-valued
     graph_dict = JSON.parsefile(graph_file)
+
 
     return StaticEnvironment(basin_ids, attributes, graph_dict)
 end
 
 # Some time information of the data
-export DateWindow
 
 """
 $(TYPEDEF)
@@ -81,14 +86,26 @@ $(TYPEDSIGNATURES)
 build a DateWindow with keyword arguments.
 """
 function DateWindow(;
-    start_date::Union{Date,Nothing} = nothing,
-    end_date::Union{Date,Nothing} = nothing,
-    date_step::Union{DatePeriod,Nothing} = nothing,
-    )
+    start_date::Union{Date, Nothing} = nothing,
+    end_date::Union{Date, Nothing} = nothing,
+    date_step::Union{DatePeriod, Nothing} = nothing,
+)
     return DateWindow(start_date, end_date, date_step)
-    
+
 end
 
+function get_all_dates(dw::DateWindow)
+    return collect((dw.start_date):(dw.date_step):(dw.end_date))
+end
+
+function Base.iterate(dw::DateWindow; n_steps::Int = 1)
+    date_step = dw.date_step
+    return DateWindow(
+        dw.start_date + n_steps * date_step,
+        dw.end_date + n_steps * date_step,
+        date_step,
+    )
+end
 # Dynamic Data Objects
 
 """
@@ -166,9 +183,13 @@ function Environment(
     
     static_env = StaticEnvironment(basin_ids_file, attributes_file, graph_file)
     basin_ids = static_env.basin_ids
-    dynamic_env =
-        DynamicEnvironment(basin_ids, forcing_timeseries_files, date_window, output_dir)
-    
+    dynamic_env = DynamicEnvironment(
+        basin_ids,
+        forcing_timeseries_files,
+        date_window,
+        output_dir,
+    )
+
     return Environment(static_env, dynamic_env)
     
 end
@@ -203,9 +224,13 @@ function Environment(
             forcing_timeseries_dir,
             forcing_timeseries_file_prefix * "$(id).csv",
         ) for id in basin_ids
-            ]
-    dynamic_env =
-        DynamicEnvironment(basin_ids, forcing_timeseries_files, date_window, output_dir)
+    ]
+    dynamic_env = DynamicEnvironment(
+        basin_ids,
+        forcing_timeseries_files,
+        date_window,
+        output_dir,
+    )
 
     return Environment(static_env, dynamic_env)
     

--- a/src/MizurouteV1.jl
+++ b/src/MizurouteV1.jl
@@ -6,15 +6,15 @@ struct MizurouteHillslopeV1{FT <: AbstractFloat} <: AbstractHillslopeModel
     shape::FT
     "Timescale factor, θ [day]"
     timescale::FT
-    "Max time (days)"
-    t_max::FT
+    "Max time (integer days)"
+    t_max::Int
 end
 # MizurouteHillslopeV1(x,y) 
 
 function MizurouteHillslopeV1{FT}() where {FT <: AbstractFloat}
     shape = FT(1.5)
     timescale = FT(1.0)
-    t_max = FT(60.0)
+    t_max = 60
     return MizurouteHillslopeV1(shape, timescale, t_max)
 end
 
@@ -23,13 +23,13 @@ struct MizurouteChannelV1{FT <: AbstractFloat} <: AbstractChannelModel
     wave_velocity::FT
     "Diffusivity, D [m²/day] (adjusted)"
     diffusivity::FT
-    "Max time (days)"
-    t_max::FT
+    "Max time (integer days)"
+    t_max::Int
 end
 
 function MizurouteChannelV1{FT}() where {FT <: AbstractFloat}
     wave_velocity = FT(1.5 * 86400)
     diffusivity = FT(800 * 86400)
-    t_max = FT(120.0)
+    t_max = 120
     return MizurouteChannelV1(wave_velocity, diffusivity, t_max)
 end

--- a/src/MizurouteV1.jl
+++ b/src/MizurouteV1.jl
@@ -18,8 +18,6 @@ function MizurouteHillslopeV1{FT}() where {FT <: AbstractFloat}
     return MizurouteHillslopeV1(shape, timescale, t_max)
 end
 
-function update_state_from_hillslope!(river_state, hillslope_model, environment) end
-
 struct MizurouteChannelV1{FT <: AbstractFloat} <: AbstractChannelModel
     "Wave velocity, C [m/day]"
     wave_velocity::FT

--- a/src/RiverModels.jl
+++ b/src/RiverModels.jl
@@ -19,52 +19,5 @@ struct HillslopeChannelRiverModel{
 end
 
 
-function compute_streamflow(
-    river_state::RS,
-    static_env::SE,
-    dynamic_env::DE,
-) where {RS <: RiverState, SE <: StaticEnvironment, DE <: DynamicEnvironment}
-
-    output_dir = dynamic_env.output_dir
-
-    all_basin_ids = static_env.basin_ids
-
-    for basin_id in all_basin_ids
-        channel_file = joinpath(output_dir, "channel_basin_$basin_id.csv")
-        hillslope_file = joinpath(output_dir, "hillslope_basin_$basin_id.csv")
-        total_file = joinpath(output_dir, "basin_$basin_id.csv")
-
-        # Check if files exist
-        if !(isfile(channel_file) && isfile(hillslope_file))
-            println("One or more files for basin_id $basin_id are missing.")
-            return nothing
-        end
-
-        channel_df = CSV.read(channel_file, DataFrame)
-        hillslope_df = CSV.read(hillslope_file, DataFrame)
-
-        # Compute the sum of hillslope and channel streamflows
-        total_streamflow = hillslope_df.streamflow .+ channel_df.streamflow
-
-        # Create a new DataFrame with the results
-        result_df = DataFrame(
-            date = channel_df.date,
-            total_streamflow = total_streamflow,
-        )
-
-        # Save the DataFrame to a new CSV
-        CSV.write(total_file, result_df)
-        println("Results saved to $total_file")
-    end
-end
-
-function compute_streamflow(
-    river_state::RS,
-    env::E,
-) where {RS <: RiverState, E <: Environment}
-    return compute_streamflow(river_state, env.static_env, env.dynamic_env)
-end
-
-
 # Specific hillslope-channel models loaded here:
 # include("MizurouteV1.jl")

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -70,7 +70,6 @@ function compute_hillslope_state(
 
     start_date = date_window.start_date
     end_date = date_window.end_date
-    dates = get_all_dates(date_window)
 
     all_basin_ids = static_env.basin_ids
     attributes_df = static_env.attributes
@@ -164,7 +163,6 @@ function compute_channel_state(
 
     start_date = date_window.start_date
     end_date = date_window.end_date
-    dates = get_all_dates(date_window)
 
     C, D = channel_model.wave_velocity, channel_model.diffusivity
     t_max = channel_model.t_max

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -27,7 +27,7 @@ function compute_streamflow(
         push!(streamflows, compute_streamflow(river_state, env))
         date_window = iterate(date_window)
     end
-    
+
     return streamflows, river_states
 end
 
@@ -56,7 +56,7 @@ function compute_river_state(
         new_channel_state,
         date_window,
     )
-   
+
 end
 
 """
@@ -82,13 +82,21 @@ function compute_hillslope_state(
 
     start_date = date_window.start_date
     end_date = date_window.end_date
+    window_length = end_date - start_date
 
     all_basin_ids = static_env.basin_ids
     attributes_df = static_env.attributes
 
     a, θ = hillslope_model.shape, hillslope_model.timescale
     t_max = hillslope_model.t_max
-
+    if window_length < Day(t_max)
+        throw(
+            ArgumentError(
+                "`DateWindow` length must exceed `HillslopeModel.t_max`.
+\n Instead, received length $(window_length) and t_max $(t_max) (days)",
+            ),
+        )
+    end
     distribution = [
         (t^(a - 1) * exp(-t / θ)) / (θ^a * SpecialFunctions.gamma(a)) for
         t in 0:(t_max - 1)
@@ -181,11 +189,20 @@ function compute_channel_state(
     all_basin_ids = static_env.basin_ids
     attributes_df = static_env.attributes
 
+    start_date = date_window.start_date
     end_date = date_window.end_date
+    window_length = (end_date - start_date)
 
     C, D = channel_model.wave_velocity, channel_model.diffusivity
     t_max = channel_model.t_max
-
+    if window_length < Day(t_max)
+        throw(
+            ArgumentError(
+                "`DateWindow` length must exceed `ChannelModel.t_max`.
+\n Instead, received length $(window_length) and t_max $(t_max) (days)",
+            ),
+        )
+    end
     # Iterate over basins in the given routing level
     new_state = Dict(eachrow([all_basin_ids zeros(length(all_basin_ids))])) # id -> 0.0  
     for basin_id in all_basin_ids
@@ -218,11 +235,11 @@ function compute_channel_state(
             x = dist[1]
             distribution = [
                 x / (2 * t * sqrt(π * D * t)) *
-                exp(-((C * t - x)^2 / (4 * D * t))) for
-                t in 1:min(t_max, length(up_timeseries))
+                exp(-((C * t - x)^2 / (4 * D * t))) for t in 1:t_max
             ]
 
-            streamflow = dot(up_q[:], distribution[end:-1:1]) # q(t) = sum(q(s)*dist(t-s))
+            streamflow =
+                dot(up_q[(end - t_max + 1):end], distribution[end:-1:1]) # q(t) = sum(q(s)*dist(t-s))
 
             new_state[basin_id] += streamflow # get final streamflow
         end
@@ -260,7 +277,11 @@ function compute_streamflow(
     river_state::RS,
     static_env::SE,
     dynamic_env::DE,
-) where {RS <: HillslopeChannelRiverState, SE <: StaticEnvironment, DE <: DynamicEnvironment}
+) where {
+    RS <: HillslopeChannelRiverState,
+    SE <: StaticEnvironment,
+    DE <: DynamicEnvironment,
+}
 
     output_dir = dynamic_env.output_dir
     all_basin_ids = static_env.basin_ids

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -5,6 +5,11 @@ export compute_streamflow,
 using CSV, DataFrames, Dates, DSP, SpecialFunctions
 
 # methods
+"""
+$(TYPEDSIGNATURES)
+
+Iterating the `initial_date_window` until the `end_date`, return a `river_state` and streamflow from each `date_window`
+"""
 function compute_streamflow(
     initial_date_window::DateWindow,
     river_model::HCM,
@@ -22,10 +27,15 @@ function compute_streamflow(
         push!(streamflows, compute_streamflow(river_state, env))
         date_window = iterate(date_window)
     end
-
+    
     return streamflows, river_states
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Compute and return the `HillslopeChannelRiverState` for this `date_window`.
+"""
 function compute_river_state(
     date_window::DateWindow,
     river_model::HCM,
@@ -41,16 +51,18 @@ function compute_river_state(
         river_model.channel_model,
         env,
     )
-
     return HillslopeChannelRiverState(
         new_hillslope_state,
         new_channel_state,
         date_window,
     )
-
-
+   
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+"""
 function compute_hillslope_state(
     date_window::DateWindow,
     hillslope_model::HM,
@@ -103,6 +115,11 @@ function compute_hillslope_state(
 
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Computes the hillslope state, by convolving a weighted `forcing_timeseries` and `hillslope_model` delay distribution over the `date_window`.
+"""
 function compute_hillslope_state(
     date_window::DateWindow,
     hillslope_model::HM,
@@ -142,6 +159,9 @@ function get_upstream_basins(basin_id::String, graph_dict::Dict)
     return unique(upstream_basin_list)
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function compute_channel_state(
     new_hillslope::Dict,
     date_window::DateWindow,
@@ -161,7 +181,6 @@ function compute_channel_state(
     all_basin_ids = static_env.basin_ids
     attributes_df = static_env.attributes
 
-    start_date = date_window.start_date
     end_date = date_window.end_date
 
     C, D = channel_model.wave_velocity, channel_model.diffusivity
@@ -214,6 +233,11 @@ function compute_channel_state(
 end
 
 
+"""
+$(TYPEDSIGNATURES)
+
+Computes the channel state at the end of the `date_window`, using the `new_hillslope` state history.
+"""
 function compute_channel_state(
     new_hillslope::Dict,
     date_window::DateWindow,
@@ -229,18 +253,20 @@ function compute_channel_state(
     )
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function compute_streamflow(
     river_state::RS,
     static_env::SE,
     dynamic_env::DE,
-) where {RS <: RiverState, SE <: StaticEnvironment, DE <: DynamicEnvironment}
+) where {RS <: HillslopeChannelRiverState, SE <: StaticEnvironment, DE <: DynamicEnvironment}
 
     output_dir = dynamic_env.output_dir
     all_basin_ids = static_env.basin_ids
 
     hillslope_state = river_state.hillslope_state
     channel_state = river_state.channel_state
-    date_window = river_state.date_window
 
     total_streamflow =
         Dict(eachrow([all_basin_ids repeat([NaN], length(all_basin_ids))]))
@@ -251,9 +277,14 @@ function compute_streamflow(
     return total_streamflow
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Compute the streamflow from an `Environment` and a computed `HillslopeChannelRiverState`
+"""
 function compute_streamflow(
     river_state::RS,
     env::EE,
-) where {RS <: RiverState, EE <: Environment}
+) where {RS <: HillslopeChannelRiverState, EE <: Environment}
     return compute_streamflow(river_state, env.static_env, env.dynamic_env)
 end

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -1,6 +1,8 @@
 # general methods for routing rivers
 export compute_streamflow,
-    update_state_from_hillslope, update_state_from_channel
+    compute_river_state,
+    compute_channel_state,
+    compute_hillslope_state
 
 using CSV, DataFrames, Dates, DSP, SpecialFunctions
 

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -17,8 +17,7 @@ function compute_streamflow(
     streamflows = []
     while date_window.end_date <= end_date
         # @info "computing streamflow over window [$(date_window.start_date),$(date_window.end_date)]"
-        river_state =
-            compute_river_state(date_window, river_model, env)
+        river_state = compute_river_state(date_window, river_model, env)
         push!(river_states, river_state)
         push!(streamflows, compute_streamflow(river_state, env))
         date_window = iterate(date_window)
@@ -202,10 +201,11 @@ function compute_channel_state(
             x = dist[1]
             distribution = [
                 x / (2 * t * sqrt(π * D * t)) *
-                exp(-((C * t - x)^2 / (4 * D * t))) for t in 1:min(t_max,length(up_timeseries))
-            ] 
+                exp(-((C * t - x)^2 / (4 * D * t))) for
+                t in 1:min(t_max, length(up_timeseries))
+            ]
 
-            streamflow = dot(up_q[:],distribution[end:-1:1]) # q(t) = sum(q(s)*dist(t-s))
+            streamflow = dot(up_q[:], distribution[end:-1:1]) # q(t) = sum(q(s)*dist(t-s))
 
             new_state[basin_id] += streamflow # get final streamflow
         end

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -245,3 +245,50 @@ function update_state_from_channel!(
         end_date,
     )
 end
+
+
+function compute_streamflow(
+    river_state::RS,
+    static_env::SE,
+    dynamic_env::DE,
+) where {RS <: RiverState, SE <: StaticEnvironment, DE <: DynamicEnvironment}
+
+    output_dir = dynamic_env.output_dir
+
+    all_basin_ids = static_env.basin_ids
+
+    for basin_id in all_basin_ids
+        channel_file = joinpath(output_dir, "channel_basin_$basin_id.csv")
+        hillslope_file = joinpath(output_dir, "hillslope_basin_$basin_id.csv")
+        total_file = joinpath(output_dir, "basin_$basin_id.csv")
+
+        # Check if files exist
+        if !(isfile(channel_file) && isfile(hillslope_file))
+            println("One or more files for basin_id $basin_id are missing.")
+            return nothing
+        end
+
+        channel_df = CSV.read(channel_file, DataFrame)
+        hillslope_df = CSV.read(hillslope_file, DataFrame)
+
+        # Compute the sum of hillslope and channel streamflows
+        total_streamflow = hillslope_df.streamflow .+ channel_df.streamflow
+
+        # Create a new DataFrame with the results
+        result_df = DataFrame(
+            date = channel_df.date,
+            total_streamflow = total_streamflow,
+        )
+
+        # Save the DataFrame to a new CSV
+        CSV.write(total_file, result_df)
+        println("Results saved to $total_file")
+    end
+end
+
+function compute_streamflow(
+    river_state::RS,
+    env::E,
+) where {RS <: RiverState, E <: Environment}
+    return compute_streamflow(river_state, env.static_env, env.dynamic_env)
+end

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -1,8 +1,6 @@
 # general methods for routing rivers
 export compute_streamflow,
-    compute_river_state,
-    compute_channel_state,
-    compute_hillslope_state
+    compute_river_state, compute_channel_state, compute_hillslope_state
 
 using CSV, DataFrames, Dates, DSP, SpecialFunctions
 

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -18,7 +18,7 @@ function compute_streamflow(
     while date_window.end_date <= end_date
         # @info "computing streamflow over window [$(date_window.start_date),$(date_window.end_date)]"
         river_state =
-            compute_river_state(date_window, river_model, env, date_window.end_date)
+            compute_river_state(date_window, river_model, env)
         push!(river_states, river_state)
         push!(streamflows, compute_streamflow(river_state, env))
         date_window = iterate(date_window)
@@ -31,7 +31,6 @@ function compute_river_state(
     date_window::DateWindow,
     river_model::HCM,
     env::E,
-    end_date::Date,
 ) where {HCM <: HillslopeChannelRiverModel, E <: Environment}
 
     new_hillslope_state =

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -18,7 +18,7 @@ function compute_streamflow(
     while date_window.end_date <= end_date
         # @info "computing streamflow over window [$(date_window.start_date),$(date_window.end_date)]"
         river_state =
-            compute_river_state(date_window, river_model, env, end_date)
+            compute_river_state(date_window, river_model, env, date_window.end_date)
         push!(river_states, river_state)
         push!(streamflows, compute_streamflow(river_state, env))
         date_window = iterate(date_window)
@@ -203,14 +203,12 @@ function compute_channel_state(
             x = dist[1]
             distribution = [
                 x / (2 * t * sqrt(π * D * t)) *
-                exp(-((C * t - x)^2 / (4 * D * t))) for t in 1:t_max
-            ]
+                exp(-((C * t - x)^2 / (4 * D * t))) for t in 1:min(t_max,length(up_timeseries))
+            ] 
 
-            # perform convolution
-            streamflow[:, 1] =
-                DSP.conv(up_q[:, 1], distribution)[1:size(up_q)[1]]
+            streamflow = dot(up_q[:],distribution[end:-1:1]) # q(t) = sum(q(s)*dist(t-s))
 
-            new_state[basin_id] += streamflow[end] # get final streamflow
+            new_state[basin_id] += streamflow # get final streamflow
         end
 
     end

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -1,66 +1,78 @@
 # general methods for routing rivers
-export compute_streamflow!,
-    update_state_from_hillslope!, update_state_from_channel!
+export compute_streamflow,
+    update_state_from_hillslope, update_state_from_channel
 
 using CSV, DataFrames, Dates, DSP, SpecialFunctions
 
 # methods
-function compute_streamflow!(
-    river_state::RS,
+function compute_streamflow(
+    initial_date_window::DateWindow,
     river_model::HCM,
     env::E,
-    start_date::Date,
     end_date::Date,
-) where {RS <: RiverState, HCM <: HillslopeChannelRiverModel, E <: Environment}
-    update_state!(river_state, river_model, env, start_date, end_date)
-    return compute_streamflow(river_state, env)
+) where {HCM <: HillslopeChannelRiverModel, E <: Environment}
+
+    date_window = initial_date_window
+    river_states = []
+    streamflows = []
+    while date_window.end_date <= end_date
+        # @info "computing streamflow over window [$(date_window.start_date),$(date_window.end_date)]"
+        river_state =
+            compute_river_state(date_window, river_model, env, end_date)
+        push!(river_states, river_state)
+        push!(streamflows, compute_streamflow(river_state, env))
+        date_window = iterate(date_window)
+    end
+
+    return streamflows, river_states
 end
 
-function update_state!(
-    river_state::RS,
+function compute_river_state(
+    date_window::DateWindow,
     river_model::HCM,
     env::E,
-    start_date::Date,
     end_date::Date,
-) where {RS <: RiverState, HCM <: HillslopeChannelRiverModel, E <: Environment}
-    update_state_from_hillslope!(
-        river_state,
-        river_model.hillslope_model,
-        env,
-        start_date,
-        end_date,
-    )
-    update_state_from_channel!(
-        river_state,
+) where {HCM <: HillslopeChannelRiverModel, E <: Environment}
+
+    new_hillslope_state =
+        compute_hillslope_state(date_window, river_model.hillslope_model, env)
+
+    new_channel_state = compute_channel_state(
+        new_hillslope_state,
+        date_window,
         river_model.channel_model,
         env,
-        start_date,
-        end_date,
     )
+
+    return HillslopeChannelRiverState(
+        new_hillslope_state,
+        new_channel_state,
+        date_window,
+    )
+
+
 end
 
-function update_state_from_hillslope!(
-    river_state::RS,
+function compute_hillslope_state(
+    date_window::DateWindow,
     hillslope_model::HM,
     static_env::SE,
     dynamic_env::DE,
-    start_date::Date,
-    end_date::Date,
 ) where {
-    RS <: RiverState,
     HM <: AbstractHillslopeModel,
     SE <: StaticEnvironment,
     DE <: DynamicEnvironment,
 }
-    println("Starting hillslope update")
-
     # Constants
     day_to_s = 86400
     km²_to_m² = 1000000
 
     forcing_timeseries = dynamic_env.forcing_timeseries
     output_dir = dynamic_env.output_dir
-    dates = collect(start_date:Day(1):end_date)
+
+    start_date = date_window.start_date
+    end_date = date_window.end_date
+    dates = get_all_dates(date_window)
 
     all_basin_ids = static_env.basin_ids
     attributes_df = static_env.attributes
@@ -73,6 +85,8 @@ function update_state_from_hillslope!(
         t in 0:(t_max - 1)
     ]
 
+    new_state =
+        Dict(eachrow([all_basin_ids repeat([[NaN]], length(all_basin_ids))])) # id -> vector{Float64}}  
     for basin_id in all_basin_ids
         timeseries_df = forcing_timeseries[basin_id]
         filtered_df =
@@ -85,34 +99,28 @@ function update_state_from_hillslope!(
 
         streamflow = DSP.conv(runoff, distribution)[1:size(runoff)[1], :][:]
 
-        output_df = DataFrame(date = dates, streamflow = streamflow)
-
-        CSV.write(
-            joinpath(output_dir, "hillslope_basin_$basin_id.csv"),
-            output_df,
-        )
+        new_state[basin_id] = streamflow
     end
+
+    return new_state
+
 end
 
-function update_state_from_hillslope!(
-    river_state::RS,
+function compute_hillslope_state(
+    date_window::DateWindow,
     hillslope_model::HM,
     env::EE,
-    start_date::Date,
-    end_date::Date,
-) where {RS <: RiverState, HM <: AbstractHillslopeModel, EE <: Environment}
-    update_state_from_hillslope!(
-        river_state,
+) where {HM <: AbstractHillslopeModel, EE <: Environment}
+    return compute_hillslope_state(
+        date_window,
         hillslope_model,
         env.static_env,
         env.dynamic_env,
-        start_date,
-        end_date,
     )
 end
 
 # Recursive function to get a list of all upstream basins
-function get_upstream_basins(basin_id::String, graph_dict::Dict{String, Any})
+function get_upstream_basins(basin_id::String, graph_dict::Dict)
     # Base case: if the current basin has no upstream basins, return an empty list
     if isempty(graph_dict[basin_id])
         return []
@@ -137,21 +145,17 @@ function get_upstream_basins(basin_id::String, graph_dict::Dict{String, Any})
     return unique(upstream_basin_list)
 end
 
-function update_state_from_channel!(
-    river_state::RS,
+function compute_channel_state(
+    new_hillslope::Dict,
+    date_window::DateWindow,
     channel_model::CM,
     static_env::SE,
     dynamic_env::DE,
-    start_date::Date,
-    end_date::Date,
 ) where {
-    RS <: RiverState,
     CM <: AbstractChannelModel,
     SE <: StaticEnvironment,
     DE <: DynamicEnvironment,
 }
-    println("Starting channel update")
-
     km_to_m = 1e3
 
     output_dir = dynamic_env.output_dir
@@ -160,29 +164,24 @@ function update_state_from_channel!(
     all_basin_ids = static_env.basin_ids
     attributes_df = static_env.attributes
 
+    start_date = date_window.start_date
+    end_date = date_window.end_date
+    dates = get_all_dates(date_window)
+
     C, D = channel_model.wave_velocity, channel_model.diffusivity
     t_max = channel_model.t_max
 
-
     # Iterate over basins in the given routing level
+    new_state = Dict(eachrow([all_basin_ids zeros(length(all_basin_ids))])) # id -> 0.0  
     for basin_id in all_basin_ids
-        # Get current streamflow in the basin
-        timeseries_df = CSV.read(
-            joinpath(output_dir, "hillslope_basin_$basin_id.csv"),
-            DataFrame,
-        )
 
-        # Allocate streamflow from upstreams
-        up_streamflow = zeros(length(timeseries_df[:, :streamflow]))
+        timeseries_df = new_hillslope[basin_id]
 
         # Iterate over upstreams
         upstream_basin_list = get_upstream_basins(string(basin_id), graph_dict)
         for up_basin in upstream_basin_list
-            # Read DataFrame with inputs from upstream
-            up_timeseries_df = CSV.read(
-                joinpath(output_dir, "hillslope_basin_$up_basin.csv"),
-                DataFrame,
-            )
+
+            up_timeseries = new_hillslope[up_basin]
 
             # Get riverine distance until the outlet of the basin from HydroATLAS
             dist =
@@ -193,8 +192,8 @@ function update_state_from_channel!(
                 attributes_df[attributes_df.HYBAS_ID .== basin_id, :DIST_MAIN][1]
             dist *= km_to_m
 
-            # Get upstream streamflow
-            up_q = up_timeseries_df[:, :streamflow]
+            # Get upstream hillslope state
+            up_q = up_timeseries
             up_q = reshape(up_q, :, 1)
 
             # Allocate streamflow array
@@ -211,41 +210,29 @@ function update_state_from_channel!(
             streamflow[:, 1] =
                 DSP.conv(up_q[:, 1], distribution)[1:size(up_q)[1]]
 
-            up_streamflow += streamflow
+            new_state[basin_id] += streamflow[end] # get final streamflow
         end
 
-        # Get dates array
-        dates = timeseries_df.date
-
-        channel_streamflow_df =
-            DataFrame(date = dates, streamflow = up_streamflow[:, 1])
-
-        # Override streamflow timeseries
-        CSV.write(
-            joinpath(output_dir, "channel_basin_$basin_id.csv"),
-            channel_streamflow_df,
-        )
     end
+    return new_state
+
 end
 
 
-function update_state_from_channel!(
-    river_state::RS,
+function compute_channel_state(
+    new_hillslope::Dict,
+    date_window::DateWindow,
     channel_model::CM,
     env::EE,
-    start_date::Date,
-    end_date::Date,
-) where {RS <: RiverState, CM <: AbstractChannelModel, EE <: Environment}
-    update_state_from_channel!(
-        river_state,
+) where {CM <: AbstractChannelModel, EE <: Environment}
+    compute_channel_state(
+        new_hillslope,
+        date_window,
         channel_model,
         env.static_env,
         env.dynamic_env,
-        start_date,
-        end_date,
     )
 end
-
 
 function compute_streamflow(
     river_state::RS,
@@ -254,41 +241,24 @@ function compute_streamflow(
 ) where {RS <: RiverState, SE <: StaticEnvironment, DE <: DynamicEnvironment}
 
     output_dir = dynamic_env.output_dir
-
     all_basin_ids = static_env.basin_ids
 
+    hillslope_state = river_state.hillslope_state
+    channel_state = river_state.channel_state
+    date_window = river_state.date_window
+
+    total_streamflow =
+        Dict(eachrow([all_basin_ids repeat([NaN], length(all_basin_ids))]))
     for basin_id in all_basin_ids
-        channel_file = joinpath(output_dir, "channel_basin_$basin_id.csv")
-        hillslope_file = joinpath(output_dir, "hillslope_basin_$basin_id.csv")
-        total_file = joinpath(output_dir, "basin_$basin_id.csv")
-
-        # Check if files exist
-        if !(isfile(channel_file) && isfile(hillslope_file))
-            println("One or more files for basin_id $basin_id are missing.")
-            return nothing
-        end
-
-        channel_df = CSV.read(channel_file, DataFrame)
-        hillslope_df = CSV.read(hillslope_file, DataFrame)
-
-        # Compute the sum of hillslope and channel streamflows
-        total_streamflow = hillslope_df.streamflow .+ channel_df.streamflow
-
-        # Create a new DataFrame with the results
-        result_df = DataFrame(
-            date = channel_df.date,
-            total_streamflow = total_streamflow,
-        )
-
-        # Save the DataFrame to a new CSV
-        CSV.write(total_file, result_df)
-        println("Results saved to $total_file")
+        total_streamflow[basin_id] =
+            hillslope_state[basin_id][end] + channel_state[basin_id]
     end
+    return total_streamflow
 end
 
 function compute_streamflow(
     river_state::RS,
-    env::E,
-) where {RS <: RiverState, E <: Environment}
+    env::EE,
+) where {RS <: RiverState, EE <: Environment}
     return compute_streamflow(river_state, env.static_env, env.dynamic_env)
 end

--- a/src/States.jl
+++ b/src/States.jl
@@ -4,9 +4,9 @@ export RiverState, HillslopeChannelRiverState
 abstract type RiverState end
 
 struct HillslopeChannelRiverState <: RiverState
-    "Hillslope state history [Dict(id -> Matrix: time-within-lag (end=current) x basin)]"
+    "Hillslope state history [Dict(id -> Vector: time-within-lag (end=current)]"
     hillslope_state::Dict
-    "Channel state [Dict(id -> Matrix: 1 x basin)]"
+    "Channel state [Dict(id -> Float)]"
     channel_state::Dict
     "Date window [DateWindow] of the state history"
     date_window::DateWindow

--- a/src/States.jl
+++ b/src/States.jl
@@ -3,32 +3,11 @@ export RiverState, HillslopeChannelRiverState
 
 abstract type RiverState end
 
-
-struct HillslopeChannelRiverState{AM <: AbstractMatrix} <: RiverState
-    hillslope::AM # instantaneous
-    channel::AM # instantaneous
+struct HillslopeChannelRiverState <: RiverState
+    "Hillslope state history [Dict(id -> Matrix: time-within-lag (end=current) x basin)]"
+    hillslope_state::Dict
+    "Channel state [Dict(id -> Matrix: 1 x basin)]"
+    channel_state::Dict
+    "Date window [DateWindow] of the state history"
+    date_window::DateWindow
 end
-
-# initialize method
-
-function construct_initial_river_state(environment::EE, river_model::HCRM, date_window::DateWindow) where {HCRM <: HillslopeChannelRiverModel, EE <: Environment}
-    
-    static_env = environment.static_env
-    basin_ids = static_env.basin_ids
-    n_basins = length(basin_ids)
-    
-    # compute times
-    
-    # hillslope_state
-    hillslope_state = zeros(buffer,n_basins)
-    
-    
-    # channel_state
-    channel_state = zeros(1,n_basins)
-    
-    return HillslopeChannelRiverState(hillslope_state, channel_state)
-end
-
-
-
-

--- a/src/States.jl
+++ b/src/States.jl
@@ -1,10 +1,34 @@
 # Contains the structs that are evolved by the river model, and methods to instantiate them
-export RiverState
+export RiverState, HillslopeChannelRiverState
 
-struct RiverState{AM <: AbstractMatrix}
+abstract type RiverState end
+
+
+struct HillslopeChannelRiverState{AM <: AbstractMatrix} <: RiverState
     hillslope::AM # instantaneous
     channel::AM # instantaneous
 end
 
 # initialize method
-# initialize_state(river_model::HCRM) where {HCRM <: HillslopChannelRiverModel} end
+
+function construct_initial_river_state(environment::EE, river_model::HCRM, date_window::DateWindow) where {HCRM <: HillslopeChannelRiverModel, EE <: Environment}
+    
+    static_env = environment.static_env
+    basin_ids = static_env.basin_ids
+    n_basins = length(basin_ids)
+    
+    # compute times
+    
+    # hillslope_state
+    hillslope_state = zeros(buffer,n_basins)
+    
+    
+    # channel_state
+    channel_state = zeros(1,n_basins)
+    
+    return HillslopeChannelRiverState(hillslope_state, channel_state)
+end
+
+
+
+

--- a/test/hillslope_channel_model.jl
+++ b/test/hillslope_channel_model.jl
@@ -17,7 +17,7 @@ end
     FT = Float32
     shape = FT(1.5)
     timescale = FT(1.0)
-    t_max_hs = FT(60.0)
+    t_max_hs = 60
     slope1 = MizurouteHillslopeV1(shape, timescale, t_max_hs)
     slope2 = MizurouteHillslopeV1{FT}()
     @test slope1.shape == slope2.shape
@@ -30,7 +30,7 @@ end
     FT = Float64
     wave_velocity = FT(1.5 * 86400)
     diffusivity = FT(800 * 86400)
-    t_max_ch = FT(120.0)
+    t_max_ch = 120
     channel1 = MizurouteChannelV1(wave_velocity, diffusivity, t_max_ch)
     channel2 = MizurouteChannelV1{FT}()
     @test channel1.wave_velocity == channel2.wave_velocity


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #21
- Closes #22
- Closes #23

Naturally this also solves: 
- Closes #32
- Closes #33
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- It is now much slower ~20s for the small basin sim. However we will only be running this once per day, so maybe that is "ok"?
- States are also stored as Dicts, updating their values is inefficient(?): possibly Dataframes are better? Or just other forms of preallocation.
- Possibly use DateTime over Date if finer resolution might be useful
- Check complete docstrings

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- t_max is now stored as an Int not a float, as it is used as an index. 
- Implement storage of time as dates within a `DateWindow`, containing start[Date]/end[Date]/iteration[DatePeriod]. 
- No CSV files are used to read/write state data. Instead the returned solution is a Vector of `streamflows`, and a vector `river states`
- The core integration loop is replaced by the following steps (i.e. a next-step map)
https://github.com/CliMA/ClimaRivers.jl/blob/7d1a70004d9dd789a45b88441d24c8f153e1b796/src/Routing.jl#L8-L28
- The next-step map computation is now replaced by the following steps
https://github.com/CliMA/ClimaRivers.jl/blob/7d1a70004d9dd789a45b88441d24c8f153e1b796/src/Routing.jl#L30-L51
- removed convolution - replacing with direct integral (faster at a point) - solutions remain the same to machine precision
## Misc
- Checked solutions are exactly the same as files posted in #18
- Example now saves state as JLD2

## On PR merge - create the following issues:
- To update current state in-place, save at allocated frequency/dates
- Precompute the distribution etc. L204 for the whole graph
- Create a Utilities, storing the Datewindow and Graph navigation tools 
- Refine the creation of reading forcing timeseries and lenght of datewindow to be stored in dynamic environment
- Use the t_max in the river models and the static environment to inform a suitable date window. 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
