### PR TITLE
remove type inference when Union{T, Nothing}

### DIFF
--- a/src/Environments.jl
+++ b/src/Environments.jl
@@ -186,29 +186,25 @@ function Environment(;
     forcing_timeseries_file_prefix::String = "basin_",
     forcing_timeseries_files::Union{<:Vector{String}, Nothing} = nothing,
 ) # union with nothing is not allowed a "where" statement, see detect_unbound_args in Aqua.jl
-    arg_list_one = [
-        basin_ids_file,
-        attributes_file,
-        graph_file,
-        output_dir,
-    ]
+    arg_list_one = [basin_ids_file, attributes_file, graph_file, output_dir]
     any_nothing = any([isnothing(x) for x in arg_list_one])
-    if any_nothing 
-        throw(ArgumentError("""
-        Environment must be built with values for all these keywords. But received:\n
-            basin_ids_file  = $(arg_list_one[1]), 
-            attributes_file = $(arg_list_one[2]), 
-            graph_file      = $(arg_list_one[3]), 
-            output_dir      = $(arg_list_one[4]),
-        """))
+    if any_nothing
+        throw(
+            ArgumentError(
+                """
+Environment must be built with values for all these keywords. But received:\n
+    basin_ids_file  = $(arg_list_one[1]), 
+    attributes_file = $(arg_list_one[2]), 
+    graph_file      = $(arg_list_one[3]), 
+    output_dir      = $(arg_list_one[4]),
+""",
+            ),
+        )
     end
 
-    arg_list_two = [
-        forcing_timeseries_files,
-        forcing_timeseries_dir,
-    ]
+    arg_list_two = [forcing_timeseries_files, forcing_timeseries_dir]
     all_nothing = all([isnothing(x) for x in arg_list_two])
-    if all_nothing 
+    if all_nothing
         throw(ArgumentError("""
                 Environment must be built with values for either keywords:
                     forcing_timeseries_files,
@@ -216,9 +212,9 @@ function Environment(;
                 Received neither.
                 """))
     end
-    
 
-    
+
+
     if isnothing(forcing_timeseries_dir)
         return Environment(
             basin_ids_file,
@@ -238,6 +234,6 @@ function Environment(;
         )
     else
 
-end
-    
+    end
+
 end

--- a/src/Environments.jl
+++ b/src/Environments.jl
@@ -117,7 +117,7 @@ function Environment(
     attributes_file::AS2,
     graph_file::AS3,
     forcing_timeseries_files::AV,
-    output_dir::AS4;
+    output_dir::AS4,
 ) where {
     AS1 <: AbstractString,
     AS2 <: AbstractString,
@@ -178,22 +178,47 @@ $(TYPEDSIGNATURES)
 Constructor based on keywords, where users must provide either `forcing_timeseries_dir` or `forcing_timeseries_files`.
 """
 function Environment(;
-    basin_ids_file::Union{AS1, Nothing} = nothing,
-    attributes_file::Union{AS2, Nothing} = nothing,
-    graph_file::Union{AS3, Nothing} = nothing,
-    forcing_timeseries_dir::Union{AS4, Nothing} = nothing,
-    output_dir::Union{AS5, Nothing} = nothing,
-    forcing_timeseries_file_prefix::AS6 = "basin_",
-    forcing_timeseries_files::Union{AS7, Nothing} = nothing,
-) where {
-    AS1 <: AbstractString,
-    AS2 <: AbstractString,
-    AS3 <: AbstractString,
-    AS4 <: AbstractString,
-    AS5 <: AbstractString,
-    AS6 <: AbstractString,
-    AS7 <: AbstractString,
-}
+    basin_ids_file::Union{String, Nothing} = nothing,
+    attributes_file::Union{String, Nothing} = nothing,
+    graph_file::Union{String, Nothing} = nothing,
+    forcing_timeseries_dir::Union{String, Nothing} = nothing,
+    output_dir::Union{String, Nothing} = nothing,
+    forcing_timeseries_file_prefix::String = "basin_",
+    forcing_timeseries_files::Union{<:Vector{String}, Nothing} = nothing,
+) # union with nothing is not allowed a "where" statement, see detect_unbound_args in Aqua.jl
+    arg_list_one = [
+        basin_ids_file,
+        attributes_file,
+        graph_file,
+        output_dir,
+    ]
+    any_nothing = any([isnothing(x) for x in arg_list_one])
+    if any_nothing 
+        throw(ArgumentError("""
+        Environment must be built with values for all these keywords. But received:\n
+            basin_ids_file  = $(arg_list_one[1]), 
+            attributes_file = $(arg_list_one[2]), 
+            graph_file      = $(arg_list_one[3]), 
+            output_dir      = $(arg_list_one[4]),
+        """))
+    end
+
+    arg_list_two = [
+        forcing_timeseries_files,
+        forcing_timeseries_dir,
+    ]
+    all_nothing = all([isnothing(x) for x in arg_list_two])
+    if all_nothing 
+        throw(ArgumentError("""
+                Environment must be built with values for either keywords:
+                    forcing_timeseries_files,
+                    forcing_timeseries_dir,
+                Received neither.
+                """))
+    end
+    
+
+    
     if isnothing(forcing_timeseries_dir)
         return Environment(
             basin_ids_file,
@@ -211,6 +236,8 @@ function Environment(;
             output_dir,
             forcing_timeseries_file_prefix = forcing_timeseries_file_prefix,
         )
-    end
+    else
 
+end
+    
 end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -5,10 +5,10 @@ using Aqua
 @testset "Aqua tests (performance)" begin
     ua = Aqua.detect_unbound_args_recursively(ClimaRivers)
     @test length(ua) == 0
-    if length(ua)>0
+    if length(ua) > 0
         println(ua)
     end
-    
+
     ambs = Aqua.detect_ambiguities(ClimaRivers; recursive = true)
     pkg_match(pkgname, pkdir::Nothing) = false
     pkg_match(pkgname, pkdir::AbstractString) = occursin(pkgname, pkdir)

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -5,6 +5,10 @@ using Aqua
 @testset "Aqua tests (performance)" begin
     ua = Aqua.detect_unbound_args_recursively(ClimaRivers)
     @test length(ua) == 0
+    if length(ua)>0
+        println(ua)
+    end
+    
     ambs = Aqua.detect_ambiguities(ClimaRivers; recursive = true)
     pkg_match(pkgname, pkdir::Nothing) = false
     pkg_match(pkgname, pkdir::AbstractString) = occursin(pkgname, pkdir)

--- a/test/hillslope_channel_model.jl
+++ b/test/hillslope_channel_model.jl
@@ -24,7 +24,7 @@ end
     @test slope1.timescale == slope2.timescale
     @test slope1.t_max == slope2.t_max
     @test slope1 == slope2
-    
+
 
     # Channel
     FT = Float64

--- a/test/hillslope_channel_model.jl
+++ b/test/hillslope_channel_model.jl
@@ -17,22 +17,26 @@ end
     FT = Float32
     shape = FT(1.5)
     timescale = FT(1.0)
-    slope1 = MizurouteHillslopeV1(shape, timescale)
+    t_max_hs = FT(60.0)
+    slope1 = MizurouteHillslopeV1(shape, timescale, t_max_hs)
     slope2 = MizurouteHillslopeV1{FT}()
     @test slope1.shape == slope2.shape
     @test slope1.timescale == slope2.timescale
+    @test slope1.t_max == slope2.t_max
     @test slope1 == slope2
+    
 
     # Channel
     FT = Float64
     wave_velocity = FT(1.5 * 86400)
-    diffusivity = FT(8000 * 86400)
-    channel1 = MizurouteChannelV1(wave_velocity, diffusivity)
+    diffusivity = FT(800 * 86400)
+    t_max_ch = FT(120.0)
+    channel1 = MizurouteChannelV1(wave_velocity, diffusivity, t_max_ch)
     channel2 = MizurouteChannelV1{FT}()
     @test channel1.wave_velocity == channel2.wave_velocity
     @test channel1.diffusivity == channel2.diffusivity
+    @test channel1.t_max == channel2.t_max
     @test channel1 == channel2
-
 
 
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #27 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- fix the current runtest failures in `main` (though not extending the runtests coverage here)

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Fix the `Aqua` bug by concretizing types `T` in `Union{T,Nothing}` types.
- Add `t_max` args into test pipeline and `D=8000` -> `D=800` fix to default test
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
