### PR TITLE
Speed up routing with columntable 

### DIFF
--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -111,16 +111,16 @@ function compute_hillslope_state(
     timeseries_df = forcing_timeseries[all_basin_ids[1]]
     tbl = Tables.columntable(timeseries_df)
     idx_dates = in(date_set).(tbl.date) # bottleneck, but only call once for all basins
-    
+
     for basin_id in all_basin_ids
         timeseries_df = forcing_timeseries[basin_id]
         tbl = Tables.columntable(timeseries_df)
-                
+
         basin_area =
             attributes_df[attributes_df.HYBAS_ID .== basin_id, :area][1]
         runoff =
-            (tbl.sro_sum[idx_dates] .+ tbl.ssro_sum[idx_dates]) .*
-            basin_area ./ day_to_s .* km²_to_m²
+            (tbl.sro_sum[idx_dates] .+ tbl.ssro_sum[idx_dates]) .* basin_area ./
+            day_to_s .* km²_to_m²
 
         streamflow = DSP.conv(runoff, distribution)[1:size(runoff)[1], :][:]
 

--- a/src/Routing.jl
+++ b/src/Routing.jl
@@ -20,6 +20,7 @@ function compute_streamflow(
     date_window = initial_date_window
     river_states = []
     streamflows = []
+
     while date_window.end_date <= end_date
         # @info "computing streamflow over window [$(date_window.start_date),$(date_window.end_date)]"
         river_state = compute_river_state(date_window, river_model, env)
@@ -104,14 +105,21 @@ function compute_hillslope_state(
 
     new_state =
         Dict(eachrow([all_basin_ids repeat([[NaN]], length(all_basin_ids))])) # id -> vector{Float64}}  
+
+    date_set = Set(get_all_dates(date_window))
+    # convert to column table to get row indices [MUCH faster than filtering the DF directly]
+    timeseries_df = forcing_timeseries[all_basin_ids[1]]
+    tbl = Tables.columntable(timeseries_df)
+    idx_dates = in(date_set).(tbl.date) # bottleneck, but only call once for all basins
+    
     for basin_id in all_basin_ids
         timeseries_df = forcing_timeseries[basin_id]
-        filtered_df =
-            filter(row -> start_date <= row[:date] <= end_date, timeseries_df)
+        tbl = Tables.columntable(timeseries_df)
+                
         basin_area =
             attributes_df[attributes_df.HYBAS_ID .== basin_id, :area][1]
         runoff =
-            (filtered_df[:, :sro_sum] .+ filtered_df[:, :ssro_sum]) .*
+            (tbl.sro_sum[idx_dates] .+ tbl.ssro_sum[idx_dates]) .*
             basin_area ./ day_to_s .* km²_to_m²
 
         streamflow = DSP.conv(runoff, distribution)[1:size(runoff)[1], :][:]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Profiling showed >90% of code time was spent in filtering the dataframe in src/Routing.jl. To profile, i put the script `mini_gamma_irf.jl` in a `main()` function, then used the code: 
```julia
using ProfileView
include("mini_gamma_irf.jl")
@profview main() # for precompile etc.
@profview main() # for the actual code profiling
```

- Replaced the DataFrame with columntables removed this bottleneck and allowed a much greater amount of precompilation. 
- Note: This was as fast as using set-based hashing to search the Dataframe directly, and because you can obtain the row index for the dates you require you only need to search once-per-timestep, not once-per-basin-per-timestep. so this should also scale well with increasing basin size.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
