### PR TITLE
Prevent dependabot from pushing doc previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -84,7 +84,10 @@ makedocs(
 deploydocs(
     repo = "github.com/CliMA/ClimaRivers.jl.git",
     target = "build",
-    push_preview = true,
+    push_preview = all(
+        !isempty,
+        (get(ENV, "GITHUB_TOKEN", ""), get(ENV, "DOCUMENTER_KEY", "")),
+    ),
     devbranch = "main",
     forcepush = true,
 )


### PR DESCRIPTION
See [issue](https://github.com/JuliaDocs/Documenter.jl/issues/2048) in Documenter.jl. This is the solution suggested there.

Dependabot PRs run without access to repository secrets, so `GITHUB_TOKEN`/`DOCUMENTER_KEY` are unavailable and `push_preview = true` causes doc preview pushes to fail. This only enables `push_preview` when both env vars are present.